### PR TITLE
Only initialize required subsystems

### DIFF
--- a/Lesson0/src/main.cpp
+++ b/Lesson0/src/main.cpp
@@ -5,7 +5,7 @@
  * Lesson 0: Test to make sure SDL is setup properly
  */
 int main(int argc, char** argv){
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		std::cout << "SDL_Init Error: " << SDL_GetError() << std::endl;
 		return 1;
 	}

--- a/Lesson1/src/main.cpp
+++ b/Lesson1/src/main.cpp
@@ -7,7 +7,7 @@
  */
 int main(int argc, char** argv){
 	//First we need to start up SDL, and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		std::cout << "SDL_Init Error: " << SDL_GetError() << std::endl;
 		return 1;
 	}

--- a/Lesson2/src/main.cpp
+++ b/Lesson2/src/main.cpp
@@ -63,7 +63,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 
 int main(int argc, char** argv){
 	//Start up SDL and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		logSDLError(std::cout, "SDL_Init");
 		return 1;
 	}

--- a/Lesson3/src/main.cpp
+++ b/Lesson3/src/main.cpp
@@ -70,7 +70,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 
 int main(int argc, char** argv){
 	//Start up SDL and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		logSDLError(std::cout, "SDL_Init");
 		return 1;
 	}

--- a/Lesson4/src/main.cpp
+++ b/Lesson4/src/main.cpp
@@ -68,7 +68,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 
 int main(int argc, char** argv){
 	//Start up SDL and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		logSDLError(std::cout, "SDL_Init");
 		return 1;
 	}

--- a/Lesson5/src/main.cpp
+++ b/Lesson5/src/main.cpp
@@ -72,7 +72,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y, SDL_Rect *
 
 int main(int argc, char** argv){
 	//Start up SDL and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		logSDLError(std::cout, "SDL_Init");
 		return 1;
 	}

--- a/Lesson6/src/main.cpp
+++ b/Lesson6/src/main.cpp
@@ -94,7 +94,7 @@ SDL_Texture* renderText(const std::string &message, const std::string &fontFile,
 
 int main(int argc, char** argv){
 	//Start up SDL and make sure it went ok
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+	if (SDL_Init(SDL_INIT_VIDEO) != 0){
 		logSDLError(std::cout, "SDL_Init");
 		return 1;
 	}


### PR DESCRIPTION
For example, HAPTIC subsystem is not supported on all platforms,
so trying to initialize it may fail. SDL_Init(SDL_INIT_EVERYTHING)
also fails in that case, while haptic is not even used.